### PR TITLE
Avoid attaching namespace directly (compatibility fix for byte-code compiler)

### DIFF
--- a/pkg/Crossover/tests/doRUnit.R
+++ b/pkg/Crossover/tests/doRUnit.R
@@ -23,7 +23,7 @@ if(require("RUnit", quietly=TRUE)) {
 	
 	## If desired, load the name space to allow testing of private functions
 	if (is.element(pkg, loadedNamespaces()))
-	    attach(loadNamespace(pkg), name=paste("namespace", pkg, sep=":"), pos=3)
+	    attach(list2env(as.list(asNamespace(pkg))), name=paste("namespace", pkg, sep=":"), pos=3)
 	##
 	## or simply call PKG:::myPrivateFunction() in tests
 	

--- a/pkg/Crossover/tests/doRUnit.R
+++ b/pkg/Crossover/tests/doRUnit.R
@@ -23,7 +23,7 @@ if(require("RUnit", quietly=TRUE)) {
 	
 	## If desired, load the name space to allow testing of private functions
 	if (is.element(pkg, loadedNamespaces()))
-	    attach(list2env(as.list(asNamespace(pkg))), name=paste("namespace", pkg, sep=":"), pos=3)
+	    attach(list2env(as.list(asNamespace(pkg))), name=paste("exposed", pkg, sep=":"), pos=3)
 	##
 	## or simply call PKG:::myPrivateFunction() in tests
 	

--- a/pkg/Crossover/vignettes/Crossover.Rnw
+++ b/pkg/Crossover/vignettes/Crossover.Rnw
@@ -94,10 +94,10 @@ CrossoverNamespace <- function(before, options, envir) {
   if (before) {
     ## code to be run before a chunk
     #attach(loadNamespace("Crossover"), name="namespace:Crossover", pos=3)
-    attach(loadNamespace("Crossover"), name="namespace:Crossover", pos=3, warn.conflicts=FALSE)
+    attach(list2env(as.list(asNamespace("Crossover"))), name="exposed:Crossover", pos=3, warn.conflicts=FALSE)
   } else {
     ## code to be run after a chunk
-    detach("namespace:Crossover")
+    detach("exposed:Crossover")
   }
 }
 
@@ -400,7 +400,7 @@ For known $V:=\Var(Y)=ZDZ^T+\Sigma$ the MLE and BLUE is given by
 \[\hat\beta=(X^tV^{-1}X)^{-1}X^tV^{-1}Y.\]
 
 <<detachNameSpace, echo=TRUE, eval=FALSE, include=FALSE>>=
-detach("namespace:Crossover")
+detach("exposed:Crossover")
 @
 
 

--- a/pkg/Crossover/vignettes/childs/Search.Rnw
+++ b/pkg/Crossover/vignettes/childs/Search.Rnw
@@ -49,7 +49,7 @@ For details (what are $N_p$, $N_s$, $P_z$, etc.) see \cite{j1995cyclic} and \cit
 
 <<TestOfDifferentApproaches, echo=TRUE, eval=TRUE, withNameSpace=TRUE>>=
 
-attach(loadNamespace("Crossover"), name="namespace:Crossover", pos=3, warn.conflicts=FALSE)
+attach(list2env(as.list(asNamespace("Crossover"))), name="exposed:Crossover", pos=3, warn.conflicts=FALSE)
 
 s <- 6
 p <- 3


### PR DESCRIPTION
This patch is a quick fix for the problem of attaching a namespace directly (to expose its unexported members). When a namespace is attached directly using e.g. attach(asNamespace(..., one gets an environment structure with a namespace loaded within global environments (below globalenv). This is not allowed by the byte-code compiler. The attached quick fix instead copies bindings from the namespace into a fresh environment, which is not a namespace, and hence can be within global environments. Note that for testing, one can use e.g. testthat, which already takes care of these low-level issues (in a similar way, it also copies the namespace bindings, but has also to do a bit more to support S4). This patch only fixes the code under "pkg", which gets into the CRAN packages, but there are remaining instances of this elsewhere in the code. For development, one could probably use devtools::load_all to access unexported members.
